### PR TITLE
st1 [2036][IMP] mrp_production_component_lot_constraint: change_prod_qty()

### DIFF
--- a/mrp_production_component_lot_constraint/__manifest__.py
+++ b/mrp_production_component_lot_constraint/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "MRP Production Component Lot Constraint",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Manufacturing",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/mrp_production_component_lot_constraint/wizards/change_production_qty.py
+++ b/mrp_production_component_lot_constraint/wizards/change_production_qty.py
@@ -7,30 +7,63 @@ from odoo import api, models
 class ChangeProductionQty(models.TransientModel):
     _inherit = "change.production.qty"
 
+    def _get_move_lot_quants(self):
+        self.ensure_one()
+        res = {}
+        for move in self.mo_id.move_raw_ids.filtered(lambda x: x.needs_lots):
+            lots = move.move_line_ids.mapped("lot_id")
+            move._do_unreserve()
+            quants = self.env["stock.quant"].search(
+                [
+                    ("location_id", "child_of", move.location_id.id),
+                    ("product_id", "=", move.product_id.id),
+                    ("quantity", ">", 0),
+                    ("lot_id", "in", lots.ids),
+                ]
+            )
+            res[move.id] = quants
+        return res
+
     @api.multi
     def change_prod_qty(self):
+        self.ensure_one()
+        # Form a dict of the moves and the assigned quants before the quants are
+        # unreserved in the process of change_prod_qty()
+        move_lot_quants = self._get_move_lot_quants()
+        # Prevent assigning unwanted quants with skip_action_assign context.
         self = self.with_context(skip_action_assign=True)
         res = super().change_prod_qty()
         assign_manual_quants = self.env["assign.manual.quants"]
         fields_list = assign_manual_quants.fields_get().keys()
-        # Following steps intends to automatically update the reserved
-        # quantities of already selected lots.
-        for wizard in self:
-            for move in wizard.mo_id.move_raw_ids.filtered(lambda x: x.needs_lots):
+        # Following steps intends to redo the reservation of the quants that had been
+        # assigned before being unreserved.
+        for move in self.mo_id.move_raw_ids:
+            if move.product_id.type == "product":
                 vals = assign_manual_quants.with_context(active_id=move.id).default_get(
                     fields_list
                 )
                 assign_quant_rec = assign_manual_quants.with_context(
-                    active_id=move.id
+                    active_id=move.id,
                 ).create(vals)
-                for line in assign_quant_rec.quants_lines.filtered(
-                    lambda x: x.selected
-                ):
-                    # Below steps should be consistent with
-                    # _onchange_selected() of assign.manual.quants
-                    line.qty = 0.0
-                    quant_qty = line.on_hand - line.reserved
-                    remaining_qty = line.assign_wizard.move_qty
-                    line.qty = min(quant_qty, remaining_qty)
+                if move.needs_lots:
+                    for quant in move_lot_quants[move.id]:
+                        for line in assign_quant_rec.quants_lines.filtered(
+                            lambda x: x.quant_id == quant
+                        ):
+                            line.selected = True
+                            line._onchange_selected()
+                else:
+                    # Taking following steps since move._action_assign() does not seem
+                    # to work here.
+                    line = assign_quant_rec.quants_lines[:1]
+                    if line:
+                        line.selected = False
+                        line._onchange_selected()
+                        line.selected = True
+                        line._onchange_selected()
                 assign_quant_rec.assign_quants()
+            else:
+                # For 'consu' type.
+                # FIXME This _action_assign() does not seem to work for some reason.
+                move._action_assign()
         return res


### PR DESCRIPTION
[2036](https://www.quartile.co/web?debug=1#id=2036&action=771&model=project.task&view_type=form&menu_id=505)

Before this change, the production quantity change operation would generate rather
random/inconsistent outputs in terms of the component reservation.

This update should prevent the removal of the already assigned lots, and re-reserve
the quants for each compnent move according to the new quantities.